### PR TITLE
Wrong URL for the S3 AWS bucket

### DIFF
--- a/docs/sap-ai-core/grounding-generic-secrets-for-aws-s3-526b0ba.md
+++ b/docs/sap-ai-core/grounding-generic-secrets-for-aws-s3-526b0ba.md
@@ -67,7 +67,7 @@ Name of the generic secret to be created
 </td>
 <td valign="top">
 
-Base64 encoded value in the format <code>https://s3-<i class="varname">&lt;region&gt;</i>.amazonaws.com</code>
+Base64 encoded value in the format <code>https://s3.<i class="varname">&lt;region&gt;</i>.amazonaws.com</code>
 
 </td>
 </tr>


### PR DESCRIPTION
The URL was wrong:
https://s3-<region>.amazonaws.com
Correct is:
https://s3.<region>.amazonaws.com

https://docs.aws.amazon.com/AmazonS3/latest/API/RESTAPI.html?utm_source=chatgpt.com

I would recommend to also include the AmazonS3 documentation link somewhere in the help document

<!-------------------------------------------------------------------------------------------
Note that this proposal is visible on github.com for anyone to see.
Refrain from sharing sensitive information.
-------------------------------------------------------------------------------------------->

